### PR TITLE
docs change for instruct embeddings

### DIFF
--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -78,7 +78,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
 class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
     """Wrapper around sentence_transformers embedding models.
 
-    To use, you should have the ``sentence_transformers`` python package installed.
+    To use, you should have the ``sentence_transformers`` and ``InstructorEmbedding`` python package installed.
 
     Example:
         .. code-block:: python


### PR DESCRIPTION
In order to use instruct embeddings the `InstructorEmbedding` python package needs to be installed.